### PR TITLE
Add leading slash to reference correct namespace

### DIFF
--- a/src/Contracts/Auditable.php
+++ b/src/Contracts/Auditable.php
@@ -9,7 +9,7 @@ interface Auditable
     /**
      * Auditable Model audits.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphMany<OwenIt\Auditing\Contracts\Audit>
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany<\OwenIt\Auditing\Contracts\Audit>
      */
     public function audits(): MorphMany;
 


### PR DESCRIPTION
Without the leading slash the namespace is interpreted as `OwenIt\Auditing\Contracts\OwenIt\Auditing\Contracts\Audit` by static analysis tools.

It currently produces the following error in Larastan:
```bash
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   Console/Commands/xxxxxxxxxx.php
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------
         Class OwenIt\Auditing\Contracts\OwenIt\Auditing\Contracts\Audit was not found while trying to analyse it - discovering symbols is probably not configured properly.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------
```